### PR TITLE
Separate dockerfiles for dask & distributed

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -1,3 +1,11 @@
+DOCKER_FILE:
+  - dask.Dockerfile
+  - distributed.Dockerfile
+
+BUILD_IMAGE:
+  - gpuci/dask
+  - gpuci/distributed
+
 CUDA_VER:
   - '11.2'
 
@@ -13,4 +21,8 @@ RAPIDS_VER:
 UCX_PY_VER:
   - '0.21'
 
-excludes: {}
+excludes:
+  - DOCKER_FILE: dask.Dockerfile
+    BUILD_IMAGE: gpuci/distributed
+  - DOCKER_FILE: distributed.Dockerfile
+    BUILD_IMAGE: gpuci/dask

--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -17,6 +17,7 @@ LINUX_VER:
 
 RAPIDS_VER:
   - '21.08'
+  - '21.10'
 
 UCX_PY_VER:
   - '0.21'

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -18,12 +18,10 @@ env
 gpuci_logger "Logging into Docker..."
 echo $DH_TOKEN | docker login --username $DH_USER --password-stdin &> /dev/null
 
-DOCKER_FILE="${WORKSPACE}/Dockerfile"
-BUILD_IMAGE="gpuci/dask"
 BUILD_TAG="${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}"
 
 # Setup BUILD_ARGS
-BUILD_ARGS="--squash --build-arg RAPIDS_VER=$RAPIDS_VER --build-arg CUDA_VER=$CUDA_VER --build-arg LINUX_VER=$LINUX_VER --build-arg PYTHON_VER=$PYTHON_VER"
+BUILD_ARGS="--squash --build-arg RAPIDS_VER=$RAPIDS_VER --build-arg UCX_PY_VER=$UCX_PY_VER --build-arg CUDA_VER=$CUDA_VER --build-arg LINUX_VER=$LINUX_VER --build-arg PYTHON_VER=$PYTHON_VER"
 
 # Ouput build config
 gpuci_logger "Build config info..."

--- a/dask.Dockerfile
+++ b/dask.Dockerfile
@@ -25,7 +25,7 @@ RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvid
     dask-cudf=$RAPIDS_VER \
     cupy \
     pynvml \
-    ucx-proc=*=gpu \
+    "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER
 
 # Clean up pkgs to reduce image size and chmod for all users

--- a/dask.Dockerfile
+++ b/dask.Dockerfile
@@ -22,8 +22,10 @@ RUN gpuci_mamba_retry env create -n dask --file /dask_environment.yaml
 RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
+    dask-cudf=$RAPIDS_VER \
     cupy \
     pynvml \
+    ucx-proc=*=gpu \
     ucx-py=$UCX_PY_VER
 
 # Clean up pkgs to reduce image size and chmod for all users

--- a/dask.Dockerfile
+++ b/dask.Dockerfile
@@ -9,7 +9,7 @@ ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
 
-ADD https://raw.githubusercontent.com/dask/dask/main/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_environment.yaml
+ADD https://raw.githubusercontent.com/dask/dask/main/continuous_integration/environment-$PYTHON_VER.yaml /dask_environment.yaml
 
 RUN conda config --set ssl_verify false
 

--- a/dask.Dockerfile
+++ b/dask.Dockerfile
@@ -1,0 +1,35 @@
+ARG CUDA_VER=11.2
+ARG LINUX_VER=ubuntu18.04
+
+FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
+
+ARG CUDA_VER=11.2
+ARG PYTHON_VER=3.8
+ARG RAPIDS_VER=21.08
+ARG UCX_PY_VER=0.21
+
+
+ADD https://raw.githubusercontent.com/dask/dask/main/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_environment.yaml
+
+RUN conda config --set ssl_verify false
+
+RUN conda install -c gpuci gpuci-tools
+
+RUN gpuci_conda_retry install -c conda-forge mamba
+
+RUN gpuci_mamba_retry env create -n dask --file /dask_environment.yaml
+
+RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
+    cudatoolkit=$CUDA_VER \
+    cudf=$RAPIDS_VER \
+    cupy \
+    pynvml \
+    ucx-py=$UCX_PY_VER
+
+# Clean up pkgs to reduce image size and chmod for all users
+RUN chmod -R ugo+w /opt/conda \
+    && conda clean -tipy \
+    && chmod -R ugo+w /opt/conda
+
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/bin/bash" ]

--- a/distributed.Dockerfile
+++ b/distributed.Dockerfile
@@ -9,7 +9,7 @@ ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
 
-ADD https://raw.githubusercontent.com/dask/dask/main/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_environment.yaml
+ADD https://raw.githubusercontent.com/dask/distributed/main/continuous_integration/environment-$PYTHON_VER.yaml /distributed_environment.yaml
 
 RUN conda config --set ssl_verify false
 
@@ -17,9 +17,9 @@ RUN conda install -c gpuci gpuci-tools
 
 RUN gpuci_conda_retry install -c conda-forge mamba
 
-RUN mamba env create -n dask --file /dask_environment.yaml
+RUN gpuci_mamba_retry env create -n dask --file /distributed_environment.yaml
 
-RUN mamba install -y -n dask -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
+RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
     cupy \

--- a/distributed.Dockerfile
+++ b/distributed.Dockerfile
@@ -24,6 +24,7 @@ RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvid
     cudf=$RAPIDS_VER \
     cupy \
     pynvml \
+    "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER
 
 # Clean up pkgs to reduce image size and chmod for all users


### PR DESCRIPTION
Separate out the dockerfiles for both dask & distributed.

Also fixes passing `UCX_PY_VER` to the docker build.