### PR TITLE
dask-sql image hotfixes

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -27,17 +27,19 @@ UCX_PY_VER:
 
 excludes:
   - DOCKER_FILE: dask.Dockerfile
-    BUILD_IMAGE:
-      - gpuci/distributed
-      - gpuci/dask_sql
+    BUILD_IMAGE: gpuci/distributed
+  - DOCKER_FILE: dask.Dockerfile
+    BUILD_IMAGE: gpuci/dask_sql
+
   - DOCKER_FILE: distributed.Dockerfile
-    BUILD_IMAGE:
-      - gpuci/dask
-      - gpuci/dask_sql
+    BUILD_IMAGE: gpuci/dask
+  - DOCKER_FILE: distributed.Dockerfile
+    BUILD_IMAGE: gpuci/dask_sql
+
   - DOCKER_FILE: dask_sql.Dockerfile
-    BUILD_IMAGE:
-      - gpuci/dask
-      - gpuci/distributed
+    BUILD_IMAGE: gpuci/dask
+  - DOCKER_FILE: dask_sql.Dockerfile
+    BUILD_IMAGE: gpuci/distributed
 
   - RAPIDS_VER: '21.08'
     UCX_PY_VER: '0.22'

--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -23,7 +23,7 @@ RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c 
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
-    numpy=$NUMPY_VER \
+    numpy=$NUMPY_VER
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN chmod -R ugo+w /opt/conda \


### PR DESCRIPTION
Should resolve the individual failures on the dask-sql image build, and fix the axis so that the proper builds are excluded from the matrix