### PR TITLE
Use static env file for dask-sql Docker image

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -9,7 +9,7 @@ ARG NUMPY_VER=1.21
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
-ADD https://raw.githubusercontent.com/charlesbluca/dask-sql/add-conda-yaml/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_sql_environment.yaml
+ADD https://gist.githubusercontent.com/charlesbluca/86f50bc81c5c084511ec4bde9c4dea57/raw/57c03629a916a1a31a780309795cd4843a85b6a1/dask-sql-env.yaml /dask_sql_environment.yaml
 
 RUN conda config --set ssl_verify false
 


### PR DESCRIPTION
Currently, `dask_sql.Dockerfile` is pointed at a conda env file in a branch that is actively being worked on:

- https://github.com/charlesbluca/dask-sql/tree/add-conda-yaml

Builds are failing becaues the conda env files were renamed as part of the work there; this PR points the Dockerfile to a [gist](https://gist.githubusercontent.com/charlesbluca/86f50bc81c5c084511ec4bde9c4dea57/raw/57c03629a916a1a31a780309795cd4843a85b6a1/dask-sql-env.yaml) of the relevant env file so that this is avoided moving forward.

Once https://github.com/dask-contrib/dask-sql/pull/238 is merged, we can point the Dockerfile to the conda YAMLs in dask-contrib/dask-sql.