### PR TITLE
Add workflow to update gpuCI

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-gpuci:
     runs-on: ubuntu-latest
-    if: github.repository == 'rapidsai/dask-build-environment'
+    # if: github.repository == 'rapidsai/dask-build-environment'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Get old cuDF / UCX-Py versions
-        run:
+        run: |
           echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'") >> $GITHUB_ENV
           echo $(grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1) >> $GITHUB_ENV
 
@@ -58,7 +58,7 @@ jobs:
           include: 'ci\/gpuci\/run\.sh'
           find: "case(.|\n)*esac"
           replace: |-
-            case \$RAPIDS_VER in
+            case ${{ '$RAPIDS_VER' }} in
               "${{ env.RAPIDS_VER }}")
                 UCX_PY_VER="${{ env.UCX_PY_VER }}"
                 ;;
@@ -66,7 +66,7 @@ jobs:
                 UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
                 ;;
               *)
-                echo "Unrecognized RAPIDS_VER: \${RAPIDS_VER}"
+                echo "Unrecognized RAPIDS_VER: ${{ '${RAPIDS_VER}' }}"
                 exit 1
                 ;;
             esac

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Get old cuDF / UCX-Py versions
         run:
           echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'") >> $GITHUB_ENV
-          grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1 >> $GITHUB_ENV
+          echo $(grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1) >> $GITHUB_ENV
 
       - name: Get latest cuDF nightly version
         id: cudf_latest
@@ -58,7 +58,7 @@ jobs:
           include: 'ci\/gpuci\/run\.sh'
           find: "case(.|\n)*esac"
           replace: |-
-            case $RAPIDS_VER in
+            case \$RAPIDS_VER in
               "${{ env.RAPIDS_VER }}")
                 UCX_PY_VER="${{ env.UCX_PY_VER }}"
                 ;;
@@ -66,7 +66,7 @@ jobs:
                 UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
                 ;;
               *)
-                echo "Unrecognized RAPIDS_VER: ${RAPIDS_VER}"
+                echo "Unrecognized RAPIDS_VER: \${RAPIDS_VER}"
                 exit 1
                 ;;
             esac

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
           include: 'ci\/gpuci\/run\.sh'
-          find: "case((.|\n)*)\*\)"
+          find: "case(.|\n)*esac"
           replace: |-
             case $RAPIDS_VER in
               "${{ env.RAPIDS_VER }}")
@@ -66,6 +66,10 @@ jobs:
                 UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
                 ;;
               *)
+                echo "Unrecognized RAPIDS_VER: ${RAPIDS_VER}"
+                exit 1
+                ;;
+            esac
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -67,7 +67,7 @@ jobs:
               *)
 
       - name: Create pull request
-        if: ${{ RAPID_VER != NEW_RAPIDS_VER && UCX_PY_VER != NEW_UCX_PY_VER }}
+        if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get latest cuDF nightly version
         id: cudf_latest
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.2
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
         with:
           org: "rapidsai-nightly"
           package: "cudf"
@@ -32,7 +32,7 @@ jobs:
         with:
           org: "rapidsai-nightly"
           package: "ucx-py"
-          version_system: "SemVer"
+          version_system: "CalVer"
 
       - name: Strip git tags from versions
         env:

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-gpuci:
     runs-on: ubuntu-latest
-    # if: github.repository == 'rapidsai/dask-build-environment'
+    if: github.repository == 'rapidsai/dask-build-environment'
 
     steps:
       - uses: actions/checkout@v2
@@ -77,11 +77,11 @@ jobs:
           regex: false
 
       - name: Create pull request
-        # if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
+        if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
+          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`, `UCX_PY_VER` to ${{ env.NEW_UCX_PY_VER }}"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
           reviewers: "charlesbluca"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -72,6 +72,7 @@ jobs:
             esac
 
       - name: Create pull request
+        if: ${{ RAPID_VER != NEW_RAPIDS_VER && UCX_PY_VER != NEW_UCX_PY_VER }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -1,0 +1,82 @@
+name: Check for gpuCI updates
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  update-gpuci:
+    runs-on: ubuntu-latest
+    if: github.repository == 'rapidsai/dask-build-environment'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get old cuDF / UCX-Py versions
+        run:
+          echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'") >> $GITHUB_ENV
+          grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1 >> $GITHUB_ENV
+
+      - name: Get latest cuDF nightly version
+        id: cudf_latest
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        with:
+          org: "rapidsai-nightly"
+          package: "cudf"
+          version_system: "CalVer"
+
+      - name: Get latest UCX-Py nightly version
+        id: ucx_py_latest
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        with:
+          org: "rapidsai-nightly"
+          package: "ucx-py"
+          version_system: "SemVer"
+
+      - name: Strip git tags from versions
+        env:
+          FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
+          FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
+        run: |
+          echo "NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
+          echo "NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-9}" >> $GITHUB_ENV
+
+      - name: Update axis file
+        uses: jacobtomlinson/gha-find-replace@0.1.4
+        with:
+          include: 'ci\/axis\/dask\.yaml'
+          find: "RAPIDS_VER:\n  - .*\n  - .*"
+          replace: |-
+            RAPIDS_VER:
+              - '${{ env.RAPIDS_VER }}'
+              - '${{ env.NEW_RAPIDS_VER }}'
+
+      - name: Update run file
+        uses: jacobtomlinson/gha-find-replace@0.1.4
+        with:
+          include: 'ci\/gpuci\/run\.sh'
+          find: "case((.|\n)*)\*\)"
+          replace: |-
+            case $RAPIDS_VER in
+              "${{ env.RAPIDS_VER }}")
+                UCX_PY_VER="${{ env.UCX_PY_VER }}"
+                ;;
+              "${{ env.NEW_RAPIDS_VER }}")
+                UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
+                ;;
+              *)
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
+          title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
+          reviewers: "charlesbluca"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: "upgrade-gpuci-rapids"
+          body: |
+            A new cuDF nightly version has been detected.
+
+            Updated `dask.yaml` and `run.sh` to use `${{ env.NEW_RAPIDS_VER }}`.

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           org: "rapidsai-nightly"
           package: "ucx-py"
-          version_system: "CalVer"
+          version_system: "SemVer"
 
       - name: Strip git tags from versions
         env:

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           org: "rapidsai-nightly"
           package: "ucx-py"
-          version_system: "SemVer"
+          version_system: "CalVer"
 
       - name: Strip git tags from versions
         env:

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -8,13 +8,15 @@ on:
 jobs:
   update-gpuci:
     runs-on: ubuntu-latest
-    if: github.repository == 'rapidsai/dask-build-environment'
+    # if: github.repository == 'rapidsai/dask-build-environment'
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Get old cuDF / UCX-Py versions
         run: |
+          echo OLD_RAPIDS_VER=$(grep -A 1 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'" | sed "s/'//g") >> $GITHUB_ENV
+          echo OLD_UCX_PY_VER=$(grep -m1 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1 | grep -o '".*"' | sed 's/"//g') >> $GITHUB_ENV
           echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'" | sed "s/'//g") >> $GITHUB_ENV
           echo UCX_PY_VER=$(grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1 | grep -o '".*"' | sed 's/"//g') >> $GITHUB_ENV
 
@@ -42,32 +44,40 @@ jobs:
           echo "NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
           echo "NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-9}" >> $GITHUB_ENV
 
-      - name: Update axis file
-        uses: jacobtomlinson/gha-find-replace@0.1.4
+      - name: Update new RAPIDS versions
+        uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'ci\/axis\/dask\.yaml'
-          find: "RAPIDS_VER:\n  - .*\n  - .*"
-          replace: |-
-            RAPIDS_VER:
-              - '${{ env.RAPIDS_VER }}'
-              - '${{ env.NEW_RAPIDS_VER }}'
+          include: 'ci/**'
+          find: "${{ env.RAPIDS_VER }}"
+          replace: "${{ env.NEW_RAPIDS_VER }}"
+          regex: false
 
-      - name: Update run file
-        uses: jacobtomlinson/gha-find-replace@0.1.4
+      - name: Update old RAPIDS versions
+        uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'ci\/gpuci\/run\.sh'
-          find: '\s{2}".*\)(.|\n)*\*\)'
-          replace: |-
-              "${{ env.RAPIDS_VER }}")
-                UCX_PY_VER="${{ env.UCX_PY_VER }}"
-                ;;
-              "${{ env.NEW_RAPIDS_VER }}")
-                UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
-                ;;
-              *)
+          include: 'ci/**'
+          find: "${{ env.OLD_RAPIDS_VER }}"
+          replace: "${{ env.RAPIDS_VER }}"
+          regex: false
+
+      - name: Update new UCX-Py versions
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'ci/**'
+          find: "${{ env.UCX_PY_VER }}"
+          replace: "${{ env.NEW_UCX_PY_VER }}"
+          regex: false
+
+      - name: Update old UCX-Py versions
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'ci/**'
+          find: "${{ env.OLD_UCX_PY_VER }}"
+          replace: "${{ env.UCX_PY_VER }}"
+          regex: false
 
       - name: Create pull request
-        if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
+        # if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,6 +87,6 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |
-            A new cuDF nightly version has been detected.
+            New cuDF and ucx-py nightly versions have been detected.
 
-            Updated `dask.yaml` and `run.sh` to use `${{ env.NEW_RAPIDS_VER }}`.
+            Updated `dask.yaml` and `run.sh` to use `RAPIDS_VER=${{ env.NEW_RAPIDS_VER }}` and `UCX_PY_VER=${{ env.NEW_UCX_PY_VER }}`.

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-gpuci:
     runs-on: ubuntu-latest
-    # if: github.repository == 'rapidsai/dask-build-environment'
+    if: github.repository == 'rapidsai/dask-build-environment'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Get old cuDF / UCX-Py versions
         run: |
-          echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'") >> $GITHUB_ENV
-          echo $(grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1) >> $GITHUB_ENV
+          echo RAPIDS_VER=$(grep -A 2 "RAPIDS_VER" ci/axis/dask.yaml | tail -n1 | grep -o "'.*'" | sed "s/'//g") >> $GITHUB_ENV
+          echo UCX_PY_VER=$(grep -m2 "UCX_PY_VER" ci/gpuci/run.sh | tail -n1 | grep -o '".*"' | sed 's/"//g') >> $GITHUB_ENV
 
       - name: Get latest cuDF nightly version
         id: cudf_latest

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get latest cuDF nightly version
         id: cudf_latest
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.2
         with:
           org: "rapidsai-nightly"
           package: "cudf"

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -56,9 +56,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@0.1.4
         with:
           include: 'ci\/gpuci\/run\.sh'
-          find: "case(.|\n)*esac"
+          find: '\s{2}".*\)(.|\n)*\*\)'
           replace: |-
-            case ${{ '$RAPIDS_VER' }} in
               "${{ env.RAPIDS_VER }}")
                 UCX_PY_VER="${{ env.UCX_PY_VER }}"
                 ;;
@@ -66,10 +65,6 @@ jobs:
                 UCX_PY_VER="${{ env.NEW_UCX_PY_VER }}"
                 ;;
               *)
-                echo "Unrecognized RAPIDS_VER: ${{ '${RAPIDS_VER}' }}"
-                exit 1
-                ;;
-            esac
 
       - name: Create pull request
         if: ${{ RAPID_VER != NEW_RAPIDS_VER && UCX_PY_VER != NEW_UCX_PY_VER }}


### PR DESCRIPTION
Adds a workflow similar to [dask-docker's Dask updating workflow](https://github.com/dask/dask-docker/blob/main/.github/workflows/watch-conda-forge.yml) to update the `RAPIDS_VER` and `UCX_PY_VER` used by gpuCI when a new nightlies of these packages are available.

Currently blocked by some work that needs to be done in https://github.com/jacobtomlinson/gha-anaconda-package-version.

E:

Looks like things resolved themselves - the original issue was that:

- `gha-anaconda-package-version` fails to parse ucx-py nightly versions as valid SemVers due to the tag appended (e.g. `0.23.0a211005`)
- when we set `gha-anaconda-package-version` to assume ucx-py versions are using CalVer, we circumvent this parsing failure, but because there are actually CalVer versions published for ucx-py nightlies, these get picked up instead of the latest SemVer

It looks like the CalVer packages published for ucx-py have been removed, so now the workaround for ucx-py should succeed, but long-term we may want to explore either expanding `gha-anaconda-package-version` to handle versions with tags appended, or use a different method altogether to find the latest versions.