### PR TITLE
Add dask-cuda to dask-sql env

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -23,6 +23,7 @@ RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c 
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
+    dask-cuda=$RAPIDS_VER \
     numpy=$NUMPY_VER \
     "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER


### PR DESCRIPTION
Follow up on #13; we also need dask-cuda to make a test that replicates the JVM segfaults