### PR TITLE
Bump RAPIDS to 22.02, UCX-Py to 0.24

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -13,7 +13,7 @@ LINUX_VER:
   - ubuntu18.04
 
 RAPIDS_VER:
-  - '21.10'
   - '21.12'
+  - '22.02'
 
 excludes:

--- a/ci/gpuci/run.sh
+++ b/ci/gpuci/run.sh
@@ -22,11 +22,11 @@ BUILD_TAG="${RAPIDS_VER}-cuda${CUDA_VER}-devel-${LINUX_VER}-py${PYTHON_VER}"
 
 # Setup BUILD_ARGS
 case $RAPIDS_VER in
-  "21.10")
-    UCX_PY_VER="0.22"
-    ;;
   "21.12")
     UCX_PY_VER="0.23"
+    ;;
+  "22.02")
+    UCX_PY_VER="0.24"
     ;;
   *)
     echo "Unrecognized RAPIDS_VER: ${RAPIDS_VER}"


### PR DESCRIPTION
We should now be able to start publishing images for the next set of nightlies