### PR TITLE
Revert "update-to-include-cuml-xgboost"

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -22,8 +22,6 @@ RUN gpuci_mamba_retry env create -n dask_sql --file /dask_sql_environment.yaml
 RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
-    cuml=$RAPIDS_VER \
-    xgboost \
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
     numpy=$NUMPY_VER \


### PR DESCRIPTION
This reverts commit 2cc1ed2078001fdae736cc2d340a32a85217f429.

cuML is still blocked on updating UCX-Py, so we cannot have an environment with both `cuml==22.02` and `ucx-py==0.24` yet. Once either https://github.com/rapidsai/cuml/pull/4396 or https://github.com/rapidsai/cuml/pull/4411 are in we should be safe to add these changes back in.