### PR TITLE
Change Numpy pinning to min version constraint

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -5,7 +5,7 @@ FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
 
 ARG CUDA_VER=11.2
 ARG PYTHON_VER=3.8
-ARG NUMPY_VER=1.20
+ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
@@ -24,7 +24,7 @@ RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c 
     cudf=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
-    numpy=$NUMPY_VER \
+    "numpy>=$NUMPY_VER" \
     "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER
 


### PR DESCRIPTION
As suggested by @quasiben and @pentschev, this changes the Numpy pinning to be a min version constraint for 1.20.1 (when NEP 35 was first introduced)