### PR TITLE
Reduce frequency of gpuCI update workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -2,7 +2,7 @@ name: Check for gpuCI updates
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Reduces the noisiness of this job; we probably don't need it running every hour