### PR TITLE
Add cuML and XGBoost to dask-sql gpuCI images

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -22,11 +22,13 @@ RUN gpuci_mamba_retry env create -n dask_sql --file /dask_sql_environment.yaml
 RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
+    cuml=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
     "numpy>=$NUMPY_VER" \
     "ucx-proc=*=gpu" \
-    ucx-py=$UCX_PY_VER
+    ucx-py=$UCX_PY_VER \
+    xgboost
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN chmod -R ugo+w /opt/conda \


### PR DESCRIPTION
Now that cuML's ucx-py dependency has been bumped to 0.24, we should be safe to merge this in and unblock https://github.com/dask-contrib/dask-sql/pull/330

cc @VibhuJawa @quasiben @jakirkham 