### PR TITLE
Bump `CUDA_VER` to 11.5

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -4,7 +4,7 @@ BUILD_NAME:
   - dask_sql
 
 CUDA_VER:
-  - '11.2'
+  - '11.5'
 
 PYTHON_VER:
   - '3.8'


### PR DESCRIPTION
Addresses https://github.com/rapidsai/dask-build-environment/pull/23#discussion_r769033743; also cc @quasiben I don't think CEC should come up in this case, as this should also bump the underlying CUDA version of the base image being used:

https://github.com/rapidsai/dask-build-environment/blob/1b0ceeb3bd4b28dc9273ec71d320def17de7c068/dask.Dockerfile#L4

Will be followed up with PRs to the affected Dask repos:

- https://github.com/dask/dask/pull/8489
- https://github.com/dask/distributed/pull/5604
- https://github.com/dask-contrib/dask-sql/pull/348