### PR TITLE
Fix dask-image's exclude rule

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -19,5 +19,5 @@ RAPIDS_VER:
 
 excludes:
   # dask-image gpuCI isn't dependent on RAPIDS
-  - RAPID_VER: '22.02'
-    BUILD_NAME: dask_image
+  - BUILD_NAME: dask_image
+    RAPIDS_VER: '22.02'


### PR DESCRIPTION
Noticed that the `excludes` rule for dask-image (keeping builds limited to one RAPIDS version) is incorrect, meaning it goes ignored; this PR should resolve that