### PR TITLE
Start building Python 3.9 images

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -9,6 +9,7 @@ CUDA_VER:
 
 PYTHON_VER:
   - '3.8'
+  - '3.9'
 
 LINUX_VER:
   - ubuntu18.04


### PR DESCRIPTION
To follow up on cuDF / cuML adding support for python 3.9 and deprecating 3.7, this PR adds builds for 3.9.

Once this is in, we can follow up in Dask repos by either bumping their `PYTHON_VER` to 3.9 or running gpuCI on both 3.8 and 3.9.

cc @quasiben 