### PR TITLE
Replace miniconda-cuda image by miniforge-cuda image

### DIFF
--- a/dask.Dockerfile
+++ b/dask.Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VER=11.2
 ARG LINUX_VER=ubuntu18.04
 
-FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
+FROM gpuci/miniforge-cuda:$CUDA_VER-devel-$LINUX_VER
 
 ARG CUDA_VER=11.2
 ARG PYTHON_VER=3.8

--- a/dask_image.Dockerfile
+++ b/dask_image.Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VER=11.2
 ARG LINUX_VER=ubuntu18.04
 
-FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
+FROM gpuci/miniforge-cuda:$CUDA_VER-devel-$LINUX_VER
 
 ARG CUDA_VER=11.2
 ARG PYTHON_VER=3.8

--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VER=11.2
 ARG LINUX_VER=ubuntu18.04
 
-FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
+FROM gpuci/miniforge-cuda:$CUDA_VER-devel-$LINUX_VER
 
 ARG CUDA_VER=11.2
 ARG PYTHON_VER=3.8

--- a/distributed.Dockerfile
+++ b/distributed.Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VER=11.2
 ARG LINUX_VER=ubuntu18.04
 
-FROM gpuci/miniconda-cuda:$CUDA_VER-devel-$LINUX_VER
+FROM gpuci/miniforge-cuda:$CUDA_VER-devel-$LINUX_VER
 
 ARG CUDA_VER=11.2
 ARG PYTHON_VER=3.8


### PR DESCRIPTION
`miniconda-cuda` image is removed by https://github.com/rapidsai/gpuci-build-environment/pull/248 so we need to move to `miniforge-cuda` image