### PR TITLE
Add `setuptools-rust` to dask-sql environment

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -8,6 +8,7 @@ ARG PYTHON_VER=3.8
 ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
+ARG SETUPTOOLS_RUST_VER=1.1.2
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-jdk11-dev.yaml /dask_sql_environment.yaml
 
@@ -26,6 +27,7 @@ RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c 
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
     "numpy>=$NUMPY_VER" \
+    "setuptools-rust>=$SETUPTOOLS_RUST_VER" \
     "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER \
     xgboost


### PR DESCRIPTION
This is required to run gpuCI on PRs targetting [`datafusion-sql-planner`](https://github.com/dask-contrib/dask-sql/tree/datafusion-sql-planner)