### PR TITLE
Add rust compiler to dask-sql environment

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -9,7 +9,7 @@ ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 ARG RUST_VER=1.59.0
-ARG SETUPTOOLS_RUST_VER=1.1.2
+ARG SETUPTOOLS_RUST_VER=1.2.0
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-jdk11-dev.yaml /dask_sql_environment.yaml
 

--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -8,6 +8,7 @@ ARG PYTHON_VER=3.8
 ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
+ARG RUST_VER=1.59.0
 ARG SETUPTOOLS_RUST_VER=1.1.2
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-jdk11-dev.yaml /dask_sql_environment.yaml
@@ -21,13 +22,14 @@ RUN gpuci_conda_retry install -c conda-forge mamba
 RUN gpuci_mamba_retry env create -n dask_sql --file /dask_sql_environment.yaml
 
 RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
+    "rust>=$RUST_VER" \
+    "setuptools-rust>=$SETUPTOOLS_RUST_VER" \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
     cuml=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
     "numpy>=$NUMPY_VER" \
-    "setuptools-rust>=$SETUPTOOLS_RUST_VER" \
     "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER \
     xgboost


### PR DESCRIPTION
This is also required for DataFusion development in dask-sql; also noting that the `setuptools-rust` version has been bumped to the most recent version we intend to use for dask-sql builds