### PR TITLE
Pin XGBoost to CUDA builds

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -32,7 +32,7 @@ RUN gpuci_mamba_retry install -y -n dask_sql -c rapidsai -c rapidsai-nightly -c 
     "numpy>=$NUMPY_VER" \
     "ucx-proc=*=gpu" \
     ucx-py=$UCX_PY_VER \
-    xgboost
+    "xgboost=*=cuda_*"
 
 # Clean up pkgs to reduce image size and chmod for all users
 RUN chmod -R ugo+w /opt/conda \


### PR DESCRIPTION
We are running into failures on https://github.com/dask-contrib/dask-sql/pull/565 due to picking up CPU XGBoost packages:

- https://gpuci.gpuopenanalytics.com/job/dask/job/dask-sql/job/prb/job/dask-sql-prb/818/

This PR should force us to use CUDA builds, which should move these failures up to the conda environment solve process.