### PR TITLE
Update Rust version to 1.60

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -8,7 +8,7 @@ ARG PYTHON_VER=3.8
 ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
-ARG RUST_VER=1.59.0
+ARG RUST_VER=1.60.0
 ARG SETUPTOOLS_RUST_VER=1.2.0
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-jdk11-dev.yaml /dask_sql_environment.yaml


### PR DESCRIPTION
This PR ensures dask_sql gpuci uses at least rust 1.60