### PR TITLE
Fix typo in updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -82,7 +82,7 @@ jobs:
           regex: false
 
       - name: Create pull request
-        if: ${{ env.RAPID_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
+        if: ${{ env.RAPIDS_VER != env.NEW_RAPIDS_VER && env.UCX_PY_VER != env.NEW_UCX_PY_VER }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Looks like an [auto-updating PR](https://github.com/rapidsai/dask-build-environment/pull/43) was opened prematurely due to this typo; this should make it so we hold off until 21.12 nightlies are available