### PR TITLE
Remove NumPy Pin

### DIFF
--- a/distributed.Dockerfile
+++ b/distributed.Dockerfile
@@ -9,8 +9,6 @@ ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
-# Numba 0.56 serialization fails with NumPy 1.23
-
 
 ADD https://raw.githubusercontent.com/dask/distributed/main/continuous_integration/environment-$PYTHON_VER.yaml /distributed_environment.yaml
 
@@ -25,7 +23,7 @@ RUN gpuci_mamba_retry env create -n dask --file /distributed_environment.yaml
 RUN gpuci_mamba_retry install -y -n dask -c rapidsai -c rapidsai-nightly -c nvidia -c conda-forge \
     cudatoolkit=$CUDA_VER \
     cudf=$RAPIDS_VER \
-    "numpy>=$NUMPY_VER,<1.23" \
+    "numpy>=$NUMPY_VER" \
     cupy \
     pynvml \
     "ucx-proc=*=gpu" \


### PR DESCRIPTION
Distributed's NumPy 1.23 issues were resolved in https://github.com/dask/distributed/pull/7089 .  We can now remove the pin