### PR TITLE
Resolve dask-sql `rustup` installation

### DIFF
--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -9,9 +9,11 @@ ARG NUMPY_VER=1.20.1
 ARG RAPIDS_VER=21.08
 ARG UCX_PY_VER=0.21
 
+ENV RUSTUP_HOME="/opt/rustup"
+ENV CARGO_HOME="/opt/cargo"
 ADD https://sh.rustup.rs /rustup-init.sh
 RUN sh /rustup-init.sh -y --default-toolchain=stable --profile=minimal
-ENV PATH="${HOME}/.cargo/bin:${PATH}"
+ENV PATH="/opt/cargo/bin:${PATH}"
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_sql_environment.yaml
 

--- a/dask_sql.Dockerfile
+++ b/dask_sql.Dockerfile
@@ -11,7 +11,7 @@ ARG UCX_PY_VER=0.21
 
 ADD https://sh.rustup.rs /rustup-init.sh
 RUN sh /rustup-init.sh -y --default-toolchain=stable --profile=minimal
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 
 ADD https://raw.githubusercontent.com/dask-contrib/dask-sql/main/continuous_integration/environment-$PYTHON_VER-dev.yaml /dask_sql_environment.yaml
 


### PR DESCRIPTION
The default `rustup` installation is into `/root/`, which gpuCI runners don't have permission to access.

This PR switches the installation location to `/opt/`, which gpuCI runners should be able to access.