### PR TITLE
Install `rustfmt` in dask-sql images

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -12,7 +12,7 @@ ARG UCX_PY_VER=0.21
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ADD https://sh.rustup.rs /rustup-init.sh
-RUN sh /rustup-init.sh -y --default-toolchain=stable --profile=minimal \
+RUN sh /rustup-init.sh -y --default-toolchain=stable --profile=minimal -c rustfmt \
     && chmod -R ugo+w /opt/cargo /opt/rustup
 
 COPY environment.yml /rapids.yml


### PR DESCRIPTION
It looks like we require `rustfmt` to compile `datafusion_substrait` as part of https://github.com/dask-contrib/dask-sql/pull/998; this adds that component to the Rust installation in the dask-sql images.

cc @jdye64 @ayushdg 