### PR TITLE
Update to `conda>=4.14` to resolve mamba issues

### DIFF
--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -16,7 +16,7 @@ RUN conda config --set ssl_verify false
 
 RUN conda install -c gpuci gpuci-tools
 
-RUN gpuci_conda_retry install -c conda-forge mamba conda-merge
+RUN gpuci_conda_retry install -c conda-forge mamba conda-merge "conda>=4.14"
 
 RUN cat /rapids.yml \
     | sed -r "s/CUDA_VER/${CUDA_VER}/g" \

--- a/dask_image/Dockerfile
+++ b/dask_image/Dockerfile
@@ -15,7 +15,7 @@ RUN conda config --set ssl_verify false
 
 RUN conda install -c gpuci gpuci-tools
 
-RUN gpuci_conda_retry install -c conda-forge mamba conda-merge
+RUN gpuci_conda_retry install -c conda-forge mamba conda-merge "conda>=4.14"
 
 RUN cat /rapids.yml \
     | sed -r "s/CUDA_VER/${CUDA_VER}/g" \

--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -22,7 +22,7 @@ RUN conda config --set ssl_verify false
 
 RUN conda install -c gpuci gpuci-tools
 
-RUN gpuci_conda_retry install -c conda-forge mamba conda-merge
+RUN gpuci_conda_retry install -c conda-forge mamba conda-merge "conda>=4.14"
 
 RUN cat /rapids.yml \
     | sed -r "s/CUDA_VER/${CUDA_VER}/g" \

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -16,7 +16,7 @@ RUN conda config --set ssl_verify false
 
 RUN conda install -c gpuci gpuci-tools
 
-RUN gpuci_conda_retry install -c conda-forge mamba conda-merge
+RUN gpuci_conda_retry install -c conda-forge mamba conda-merge "conda>=4.14"
 
 RUN cat /rapids.yml \
     | sed -r "s/CUDA_VER/${CUDA_VER}/g" \


### PR DESCRIPTION
Looks like `mamba>=1.3` allows incompatible `conda` versions to co-exist in the same environment, which has been raising errors during the builds:

```
15:02:22 Traceback (most recent call last):
15:02:22   File "/opt/conda/bin/mamba", line 7, in <module>
15:02:22     from mamba.mamba import main
15:02:22   File "/opt/conda/lib/python3.9/site-packages/mamba/mamba.py", line 51, in <module>
15:02:22     from mamba import repoquery as repoquery_api
15:02:22   File "/opt/conda/lib/python3.9/site-packages/mamba/repoquery.py", line 9, in <module>
15:02:22     from mamba.utils import init_api_context, load_channels
15:02:22   File "/opt/conda/lib/python3.9/site-packages/mamba/utils.py", line 17, in <module>
15:02:22     from conda.core.index import _supplement_index_with_system, check_allowlist
15:02:22 ImportError: cannot import name 'check_allowlist' from 'conda.core.index' (/opt/conda/lib/python3.9/site-packages/conda/core/index.py)
```

Bumping to `conda>=4.14` (when `check_allowlist` was introduced) should resolve these issues, xref https://github.com/conda-forge/mamba-feedstock/issues/172 