### PR TITLE
Start building images against python 3.10

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -9,7 +9,7 @@ CUDA_VER:
 
 PYTHON_VER:
   - '3.8'
-  - '3.9'
+  - '3.10'
 
 LINUX_VER:
   - ubuntu18.04


### PR DESCRIPTION
Now that we're no longer publishing RAPIDS nightlies built against 3.9, we should begin migrating Dask's GPU testing to 3.10.