### PR TITLE
Remove numpy pin override from Dask images

### DIFF
--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -27,7 +27,6 @@ RUN cat /rapids.yml \
 
 # need to unpin numpy & pyarrow in python 3.8 environment
 RUN cat /dask.yml \
-    | sed -r "s/numpy=/numpy>=/g" \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     > dask_unpinned.yml
 


### PR DESCRIPTION
We originally had an override for the Dask python 3.8 environment's numpy pinning since it would've conflicted with the `>=1.20.1` constraint set by the RAPIDS dependencies; now that https://github.com/dask/dask/pull/9950 is merged in, we should remove this override so that we're pulling in Dask's numpy minimum version.

cc @jrbourbeau