### PR TITLE
Update parsing of `FULL_RAPIDS_VER`/`FULL_UCX_PY_VER` in gpuCI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -46,8 +46,8 @@ jobs:
           FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
           FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
         run: |
-          echo "NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-10}" >> $GITHUB_ENV
-          echo "NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10}" >> $GITHUB_ENV
+          echo "NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-4}" >> $GITHUB_ENV
+          echo "NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-4}" >> $GITHUB_ENV
 
       - name: Update new RAPIDS versions
         uses: jacobtomlinson/gha-find-replace@v2


### PR DESCRIPTION
Now that cuDF/ucx-py packages have moved their publishing date to the build string, we need to update the updating workflow to parse the new version strings accordingly.