### PR TITLE
Add libfaiss to dask-sql environment

### DIFF
--- a/dask_sql/environment.yml
+++ b/dask_sql/environment.yml
@@ -14,3 +14,6 @@ dependencies:
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER
 - xgboost=*=cuda_*
+# TODO: remove once cuML is using consolidated RAFT packages
+- libfaiss>=1.7.1
+- faiss-proc=*=cuda


### PR DESCRIPTION
Currently, ML tests are failing in dask-sql because cuML requires `libfaiss` but there isn't a nightly published with it as a runtime dependency (waiting on https://github.com/rapidsai/cuml/pull/5272).

In the meantime, this PR adds the required `libfaiss` runtime dependency to the dask-sql environment to unblock CI until new cuML nightlies are published.