### PR TITLE
Always use RAPIDS-published xgboost in dask-sql images

### DIFF
--- a/dask_sql/environment.yml
+++ b/dask_sql/environment.yml
@@ -13,7 +13,4 @@ dependencies:
 - numpy>=NUMPY_VER
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER
-- xgboost=*=cuda_*
-# TODO: remove once cuML is using consolidated RAFT packages
-- libfaiss>=1.7.1
-- faiss-proc=*=cuda
+- xgboost=*rapidsaiRAPIDS_VER


### PR DESCRIPTION
Recently, the build string of RAPIDS-published XGBoost nightlies changed slightly, which caused the conda environment solve to start failing on builds of the dask-sql images.

This PR modifies the XGBoost specification to fix this failure, and pins us explicitly to the RAPIDS-published packages, as doing a specification like `xgboost=*=cuda*` would allow us to fallback on the conda-forge packages, which I don't think we want here (cc @VibhuJawa if you have any thoughts here).

Also removing the `libfaiss`/`faiss-proc` installs as those should no longer be necessary