### PR TITLE
Unpin `uvicorn` in dask-sql 3.8 environment

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -31,9 +31,10 @@ RUN cat /rapids.yml \
     | sed -r "s/NUMPY_VER/${NUMPY_VER}/g" \
     > /rapids_pinned.yml
 
-# need to unpin dask & pyarrow in python 3.8 environment
+# need to unpin dask, pyarrow, and uvicorn in python 3.8 environment
 RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
+    | sed -r "s/uvicorn=/uvicorn>=/g" \
     | sed -r "s/dask=/dask>=/g" \
     > /dask_unpinned.yml
 


### PR DESCRIPTION
Looks like the Dask version bump in `cuml` now requires a greater minimum version of `uvicorn`; this PR unpins the `uvicorn` dependency in dask-sql's 3.8 environment during image build so we can pull in the latest cuML python bindings and resolve the failures we're seeing in https://github.com/dask-contrib/dask-sql/pull/1116.