### PR TITLE
Bump `PYTHON_VER` in axis file

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -8,7 +8,7 @@ CUDA_VER:
   - '11.5'
 
 PYTHON_VER:
-  - '3.8'
+  - '3.9'
   - '3.10'
 
 LINUX_VER:


### PR DESCRIPTION
Missed this in #65, which is required to actually rebuild the 3.9 images