### PR TITLE
Install CUDA-enabled `pytorch` in Distributed environments

### DIFF
--- a/distributed/environment.yml
+++ b/distributed/environment.yml
@@ -4,11 +4,13 @@ channels:
 - rapidsai-nightly
 - conda-forge
 - nvidia
+- pytorch
 dependencies:
 - cudatoolkit=CUDA_VER
 - cudf=RAPIDS_VER
 - numpy>=NUMPY_VER
 - cupy
 - pynvml
+- pytorch=*=*cudaCUDA_VER*
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER


### PR DESCRIPTION
This should unblock the initial failures in https://github.com/dask/distributed/pull/8036