### PR TITLE
Update `xgboost` pinning in dask-sql environments

### DIFF
--- a/dask_sql/environment.yml
+++ b/dask_sql/environment.yml
@@ -13,5 +13,5 @@ dependencies:
 - numpy>=NUMPY_VER
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER
-- xgboost=*=rapidsai_*
-- libxgboost=*=rapidsai_*
+- xgboost=*=rapidsai_py*
+- libxgboost=*=rapidsai_h*

--- a/dask_sql/environment.yml
+++ b/dask_sql/environment.yml
@@ -13,4 +13,4 @@ dependencies:
 - numpy>=NUMPY_VER
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER
-- xgboost=*rapidsaiRAPIDS_VER
+- xgboost=*=rapidsai*

--- a/dask_sql/environment.yml
+++ b/dask_sql/environment.yml
@@ -13,4 +13,5 @@ dependencies:
 - numpy>=NUMPY_VER
 - ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER
-- xgboost=*=rapidsai*
+- xgboost=*=rapidsai_*
+- libxgboost=*=rapidsai_*


### PR DESCRIPTION
Looks like the version/build scheme of the RAPIDS xgboost nightlies has changed, which is causing dask-sql image builds to fail - this should unblock.