### PR TITLE
Add dask-cudf and dask-cuda to Distributed environment

### DIFF
--- a/distributed/environment.yml
+++ b/distributed/environment.yml
@@ -8,6 +8,8 @@ channels:
 dependencies:
 - cudatoolkit=CUDA_VER
 - cudf=RAPIDS_VER
+- dask-cudf=RAPIDS_VER
+- dask-cuda=RAPIDS_VER
 - numpy>=NUMPY_VER
 - cupy
 - pynvml


### PR DESCRIPTION
This should allow us to run a few of the tests getting skipped in Distributed's GPU CI, namely one added in https://github.com/dask/distributed/pull/8148 that requires dask-cuda