### PR TITLE
Resolve dask-sql/distributed build failures

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -9,6 +9,9 @@ ARG PYTHON_VER=3.9
 ARG RAPIDS_VER=23.12
 ARG UCX_PY_VER=0.35
 
+RUN apt-get update \
+    && apt-get install -y wget
+
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ADD https://sh.rustup.rs /rustup-init.sh

--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -37,6 +37,7 @@ RUN cat /rapids.yml \
 
 # need to unpin dask, pyarrow, and uvicorn in python 3.9 environment
 RUN cat /dask.yml \
+    | sed -r "s/libprotobuf=/libprotobuf>=/g" \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     | sed -r "s/uvicorn=/uvicorn>=/g" \
     | sed -r "s/dask=/dask>=/g" \

--- a/distributed/environment.yml
+++ b/distributed/environment.yml
@@ -6,6 +6,7 @@ channels:
 - nvidia
 - pytorch
 dependencies:
+- c-compiler  # needed for source installation of crick
 - cudatoolkit=CUDA_VER
 - cudf=RAPIDS_VER
 - dask-cudf=RAPIDS_VER


### PR DESCRIPTION
The switch to `rapidsai/miniforge-cuda` base images introduced a couple small build failures that this should fix; in particular:

- Need a `wget` installation in dask-sql's images to install `rustup`
- Need to loosen dask-sql CI's `libprotobuf` pinning to avoid conflict with cuDF
- Need a C compiler in distributed's images to source install `crick`