### PR TITLE
Generalize computation of `NEW_*_VER` in GPU CI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -46,8 +46,8 @@ jobs:
           FULL_RAPIDS_VER: ${{ steps.cudf_latest.outputs.version }}
           FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
         run: |
-          echo "NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-4}" >> $GITHUB_ENV
-          echo "NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-4}" >> $GITHUB_ENV
+          echo "NEW_RAPIDS_VER=$(echo $FULL_RAPIDS_VER | cut -d'.' -f1,2)" >> $GITHUB_ENV
+          echo "NEW_UCX_PY_VER=$(echo $FULL_UCX_PY_VER | cut -d'.' -f1,2)" >> $GITHUB_ENV
 
       - name: Update new RAPIDS versions
         uses: jacobtomlinson/gha-find-replace@v2


### PR DESCRIPTION
This PR fixes some flimsy logic in the GPU CI updating workflow that broke with [recent changes to RAPIDS nightly versions](https://github.com/rapidsai/rmm/pull/1347).

Closes #78