### PR TITLE
Unpin pandas in dask-sql environments

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -40,6 +40,7 @@ RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     | sed -r "s/uvicorn=/uvicorn>=/g" \
     | sed -r "s/dask=/dask>=/g" \
+    | sed -r "s/pandas=/pandas>=/g" \
     | sed -r "s/numpy=/numpy>=/g" \
     | sed -r "s/mlflow=/mlflow>=/g" \
     > /dask_unpinned.yml


### PR DESCRIPTION
Similar to #85, this unblocks failing dask-sql image builds due to RAPIDS now using pandas 2

cc @pentschev 