### PR TITLE
Unpin py-xgboost in dask-sql CI

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -43,6 +43,7 @@ RUN cat /dask.yml \
     | sed -r "s/pandas=/pandas>=/g" \
     | sed -r "s/numpy=/numpy>=/g" \
     | sed -r "s/mlflow=/mlflow>=/g" \
+    | sed -r "s/py-xgboost=/py-xgboost>=/g" \
     > /dask_unpinned.yml
 
 RUN conda-merge /rapids_pinned.yml /dask_unpinned.yml > /dask_sql.yml


### PR DESCRIPTION
This unblocks the build failures that result from the addition of `py-xgboost=1.7.0` to dask-sql's 3.9 environment in https://github.com/dask-contrib/dask-sql/pull/1301.