### PR TITLE
Unpin `numpy` in Dask environment, leave `dask` pinned in Dask-SQL environment 

### DIFF
--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -30,6 +30,7 @@ RUN cat /rapids.yml \
 RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     | sed -r "s/pandas=/pandas>=/g" \
+    | sed -r "s/numpy=/numpy>=/g" \
     > dask_unpinned.yml
 
 RUN conda-merge /rapids_pinned.yml /dask_unpinned.yml > /dask.yml

--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -39,7 +39,6 @@ RUN cat /rapids.yml \
 RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     | sed -r "s/uvicorn=/uvicorn>=/g" \
-    | sed -r "s/dask=/dask>=/g" \
     | sed -r "s/pandas=/pandas>=/g" \
     | sed -r "s/numpy=/numpy>=/g" \
     | sed -r "s/mlflow=/mlflow>=/g" \


### PR DESCRIPTION
Unblocks remaining image build failures after the merging of https://github.com/dask-contrib/dask-sql/pull/1314: 

- unpins `numpy` in Dask's GPU CI environments to accomodate UCX-Py's dependency on numpy 1.23+ (https://github.com/rapidsai/ucx-py/pull/1028)
- leave `dask` pinned in Dask-SQL's GPU CI environments since it is now pinned to match `rapids-dask-dependency` (https://github.com/dask-contrib/dask-sql/pull/1301)
