### PR TITLE
Pin to rust 1.72 in dask-sql images

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ADD https://sh.rustup.rs /rustup-init.sh
-RUN sh /rustup-init.sh -y --default-toolchain=stable --profile=minimal -c rustfmt \
+RUN sh /rustup-init.sh -y --default-toolchain=1.72 --profile=minimal -c rustfmt \
     && chmod -R ugo+rw /opt/cargo /opt/rustup
 
 COPY environment.yml /rapids.yml


### PR DESCRIPTION
Coincides with https://github.com/dask-contrib/dask-sql/pull/1333 to circumvent build failures with rust >=1.78.