### PR TITLE
Drop `mlflow` from dask-sql GPU CI environments

### DIFF
--- a/dask_sql/Dockerfile
+++ b/dask_sql/Dockerfile
@@ -41,7 +41,7 @@ RUN cat /dask.yml \
     | sed -r "s/uvicorn=/uvicorn>=/g" \
     | sed -r "s/pandas=/pandas>=/g" \
     | sed -r "s/numpy=/numpy>=/g" \
-    | sed -r "s/mlflow=/mlflow>=/g" \
+    | sed -r "/^.*- mlflow/s/^/#/g" \
     > /dask_unpinned.yml
 
 RUN conda-merge /rapids_pinned.yml /dask_unpinned.yml > /dask_sql.yml


### PR DESCRIPTION
All recent `mlflow` packages have a `pyarrow<16` constraint that prevents them from being co-installed cuDF builds as of https://github.com/rapidsai/cudf/pull/15703.

Doesn't look like we're actually running any of the tests depending on `mlflow` on GPU, we should be good to drop it from CI dependencies outright without dropping coverage.