### PR TITLE
add Python 3.12 support, prefer absolute paths in Dockerfiles

### DIFF
--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -9,6 +9,7 @@ CUDA_VER:
 PYTHON_VER:
   - '3.10'
   - '3.11'
+  - '3.12'
 
 LINUX_VER:
   - ubuntu20.04

--- a/ci/axis/dask.yaml
+++ b/ci/axis/dask.yaml
@@ -22,3 +22,6 @@ excludes:
   # dask-image gpuCI isn't dependent on RAPIDS
   - BUILD_NAME: dask_image
     RAPIDS_VER: '24.08'
+  # Python 3.12 support was first added in RAPIDS 24.10
+  - PYTHON_VER: '3.12'
+    RAPIDS_VER: '24.08'

--- a/dask/Dockerfile
+++ b/dask/Dockerfile
@@ -31,7 +31,7 @@ RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
     | sed -r "s/pandas=/pandas>=/g" \
     | sed -r "s/numpy=/numpy>=/g" \
-    > dask_unpinned.yml
+    > /dask_unpinned.yml
 
 RUN conda-merge /rapids_pinned.yml /dask_unpinned.yml > /dask.yml
 

--- a/distributed/Dockerfile
+++ b/distributed/Dockerfile
@@ -29,7 +29,7 @@ RUN cat /rapids.yml \
 # unpin problematic CI dependencies
 RUN cat /dask.yml \
     | sed -r "s/pyarrow=/pyarrow>=/g" \
-    > dask_unpinned.yml
+    > /dask_unpinned.yml
 
 RUN conda-merge /rapids_pinned.yml /dask_unpinned.yml > /distributed.yml
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/40

RAPIDS is adding support for Python 3.12 in its 24.10 release. All of the libraries used by images built from this repo (`cudf`, `dask-cudf`, `ucx-py`) have been updated... so this proposes adding Python 3.12 images here.

## Notes for Reviewers

### How I tested this

On an x86_64 machine with CUDA driver 535:

```shell
cd ./dask

docker build \
    -t delete-me:dask \
    --build-arg RAPIDS_VER="24.10" \
    --build-arg UCX_PY_VER="0.40" \
    --build-arg CUDA_VER="11.8.0" \
    --build-arg LINUX_VER="ubuntu20.04" \
    --build-arg PYTHON_VER="3.12" \
    -f ./Dockerfile \
    .

docker run \
  --rm \
  --gpus 1 \
  -it delete-me:dask \
   bash -c "source activate dask; python -c 'import cudf; print(cudf.__version__)'"
# 24.10.00a310
```