### PR TITLE
Resolve failures in updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -17,6 +17,8 @@ jobs:
         uses: the-coding-turtle/ga-yaml-parser@v0.1.2
         with:
           file: ci/axis/dask.yaml
+          export_to_envs: true
+          return_to_outputs: false
 
       - name: Get old RAPIDS / UCX-Py versions
         run: |

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -90,7 +90,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`, `UCX_PY_VER` to `${{ env.NEW_UCX_PY_VER }}`"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
-          reviewers: "charlesbluca"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |


### PR DESCRIPTION
Looks like as of #101, our scheduled run to check for GPU CI updates has been failing:

https://github.com/rapidsai/dask-build-environment/actions/runs/11023751994/job/30615634982

Digging through a failed run, seems like the issue is that `the-coding-turtle/ga-yaml-parser@v0.1.2` no longer implicitly exports the parsed YAML values to the GHA env; this PR updates the step's configuration to do this.

Also dropped my name from the list of reviewers opened by the auto-generated PR, as in practice I should now get pinged through the CODEOWNERS file.