### PR TITLE
add ci-codeowners to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @rapidsai/dask-build-environment-write
+*  @rapidsai/dask-build-environment-write @rapidsai/ci-codeowners


### PR DESCRIPTION
Proposes adding https://github.com/orgs/rapidsai/teams/ci-codeowners as CODEOWNERS for the entire repo, alongside `dask-build-environment-write`.

Coming out of a conversation in the (private) `ops` repo with @charlesbluca and @rjzamora 