### PR TITLE
remove ucx-proc dependency

### DIFF
--- a/dask/environment.yml
+++ b/dask/environment.yml
@@ -10,5 +10,4 @@ dependencies:
 - dask-cudf=RAPIDS_VER
 - cupy
 - pynvml
-- ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER

--- a/distributed/environment.yml
+++ b/distributed/environment.yml
@@ -14,5 +14,4 @@ dependencies:
 - cupy
 - pynvml
 - pytorch=*=*cudaCUDA_VER*
-- ucx-proc=*=gpu
 - ucx-py=UCX_PY_VER


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/142

`ucx-proc` has been unnecessary since UCX 1.14, and RAPIDS minimum supported UCX version is 1.15. This proposes dropping it from environments here.